### PR TITLE
Feat/54 plot color transparency adjustment

### DIFF
--- a/gdscript/components/guidot_plot.gd
+++ b/gdscript/components/guidot_plot.gd
@@ -70,6 +70,10 @@ var n_y_ax_cached: Vector2 = Vector2(1,0)
 var test_popup: PopupMenu
 
 func _ready() -> void:
+	self.name = "plot_frame"
+	self.clip_contents = true
+	self.color = Guidot_Utils.get_color("gd_black")
+
 	test_popup = PopupMenu.new()
 	add_child(test_popup)
 	test_popup.add_check_item("test")
@@ -89,12 +93,13 @@ func _ready() -> void:
 func setup_plot_anchor() -> void:
 	pass
 
-func init_plot(color: Color = Guidot_Utils.get_color("gd_black")) -> void:
-	self.name = "plot_frame"
+func init_plot(color: Color = Guidot_Utils.get_color("gd_grey")) -> void:
+	# self.name = "plot_frame"
  
-	# This helps ensuring that we do not draw anything beyond the plot frame
-	self.clip_contents = true
-	self.color = color
+	# # This helps ensuring that we do not draw anything beyond the plot frame
+	# self.clip_contents = true
+	# self.color = color
+	pass
 
 func setup_plot_frame_offset(left: float, right: float, top: float, bottom: float) -> void:
 

--- a/gdscript/components/menu/guidot_graph_manager.gd
+++ b/gdscript/components/menu/guidot_graph_manager.gd
@@ -3,6 +3,7 @@ extends Guidot_Panel2
 
 signal changes_applied
 signal y_axis_changes_applied
+signal opacity_changed(alpha: float)
 
 var selected_server: String
 
@@ -133,6 +134,45 @@ func _ready() -> void:
 	_graph_config_tab_cont.add_child(_server_config_tab)
 
 	var graph_buffer_mode_label = Guidot_Utils.create_label_row("Current mode", "Realtime", Vector2(200, 20))
+
+	var opacity_margin: MarginContainer = MarginContainer.new()
+	opacity_margin.add_theme_constant_override("margin_left", 4)
+	opacity_margin.add_theme_constant_override("margin_right", 4)
+	opacity_margin.add_theme_constant_override("margin_top", 2)
+	opacity_margin.add_theme_constant_override("margin_bottom", 2)
+
+	var opacity_hbox: HBoxContainer = HBoxContainer.new()
+	opacity_hbox.add_theme_constant_override("separation", 8)
+
+	var opacity_text: Label = Label.new()
+	opacity_text.text = "Opacity"
+	opacity_text.custom_minimum_size = Vector2(60, 0)
+	opacity_text.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+
+	var opacity_slider: HSlider = HSlider.new()
+	opacity_slider.min_value = 0.0
+	opacity_slider.max_value = 1.0
+	opacity_slider.step = 0.01
+	opacity_slider.value = 1.0
+	opacity_slider.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	opacity_slider.custom_minimum_size = Vector2(0, 20)
+
+	var opacity_value_label: Label = Label.new()
+	opacity_value_label.text = "100%"
+	opacity_value_label.custom_minimum_size = Vector2(36, 0)
+	opacity_value_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
+	opacity_value_label.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+
+	opacity_slider.value_changed.connect(func(v: float) -> void:
+		opacity_value_label.text = "%d%%" % int(v * 100)
+		opacity_changed.emit(v)
+	)
+
+	opacity_hbox.add_child(opacity_text)
+	opacity_hbox.add_child(opacity_slider)
+	opacity_hbox.add_child(opacity_value_label)
+	opacity_margin.add_child(opacity_hbox)
+
 	var add_server_btn: Button = Button.new()
 	add_server_btn.text = "+ Add Server"
 	add_server_btn.pressed.connect(self._on_add_server_pressed)
@@ -140,7 +180,7 @@ func _ready() -> void:
 	_apply_changes_btn.text = "Apply changes"
 	self._apply_changes_btn.pressed.connect(self._on_apply_changes_to_graph)
 	
-	var server_config_rows: Array[Node] = [graph_buffer_mode_label, add_server_btn, self._apply_changes_btn]
+	var server_config_rows: Array[Node] = [graph_buffer_mode_label, opacity_margin, add_server_btn, self._apply_changes_btn]
 	self.add_config_rows(self._server_config_tab, server_config_rows)
 
 	# Setup y-axis configurator

--- a/gdscript/t_graph_with_panel.gd
+++ b/gdscript/t_graph_with_panel.gd
@@ -146,7 +146,8 @@ func set_stylebox_color(color: Color) -> void:
 	_guidot_stylebox.bg_color = color
 
 func set_graph_opacity(alpha: float) -> void:
-	self.modulate.a = clamp(alpha, 0.0, 1.0)
+	var a: float = clamp(alpha, 0.0, 1.0)
+	self.set_self_modulate(Color(1.0, 1.0, 1.0, a))	
 
 func set_margin_size(val: int) -> void:
 	_guidot_stylebox.content_margin_left = val

--- a/gdscript/t_graph_with_panel.gd
+++ b/gdscript/t_graph_with_panel.gd
@@ -208,14 +208,12 @@ func _input(event: InputEvent) -> void:
 					self._last_edit_mode = self._curr_edit_mode
 					self._is_holding_left_click = false
 					self.log(LOG_DEBUG, ["Left click resizing released"])
-				elif event.is_pressed():
-					# Start dragging - calculate the offset from mouse to panel position
+				elif event.is_pressed() and self._mouse_in:
 					_is_dragging = true
-					self._curr_edit_mode == Edit_Mode.MOVE
-					# This allows the user to grab the panel anywhere within the panel and drag it
-					# anywhere
+					self._curr_edit_mode = Edit_Mode.MOVE
 					_drag_offset = get_global_mouse_position() - self.global_position
 					self._last_position = self.position
+					get_viewport().set_input_as_handled()
 				else:
 					_is_dragging = false
 

--- a/gdscript/t_graph_with_panel.gd
+++ b/gdscript/t_graph_with_panel.gd
@@ -13,7 +13,6 @@ const LOG_ERROR = Guidot_Log.Log_Level.ERROR
 @onready var _guidot_stylebox: StyleBoxFlat = StyleBoxFlat.new()
 @onready var margin_val: int = 1
 
-
 @onready var _last_mouse_position: Vector2 = Vector2()
 @onready var _mouse_in: bool = false
 
@@ -28,6 +27,10 @@ var _drag_offset: Vector2
 
 @onready var _is_in_focus: bool = false
 @onready var _is_holding_left_click: bool = false
+
+var i: float = 0
+var rate: float = 0.05
+var sign: float = 1.0
 
 enum UI_Mode {
 	SELECTED,
@@ -121,11 +124,13 @@ func _ready() -> void:
 
 	# Signals connection
 	guidot_graph.parent_focus_requested.connect(_on_parent_focused)
+	guidot_graph._graph_manager.opacity_changed.connect(self.set_graph_opacity)
 	self.mouse_entered.connect(_on_mouse_entered)
 	self.mouse_exited.connect(_on_mouse_exited)
 
 	# Hotkeys
 	self._register_hotkeys()
+
 
 func _on_mouse_entered() -> void:
 	self._mouse_in = true
@@ -139,6 +144,9 @@ func _on_parent_focused() -> void:
 
 func set_stylebox_color(color: Color) -> void:
 	_guidot_stylebox.bg_color = color
+
+func set_graph_opacity(alpha: float) -> void:
+	self.modulate.a = clamp(alpha, 0.0, 1.0)
 
 func set_margin_size(val: int) -> void:
 	_guidot_stylebox.content_margin_left = val

--- a/gdscript/t_graph_with_panel.gd
+++ b/gdscript/t_graph_with_panel.gd
@@ -281,10 +281,9 @@ func _input(event: InputEvent) -> void:
 				self.size = new_size
 				self._last_mouse_position = curr_mouse_pos_global
 
-			if self._is_dragging and self._mouse_in:
+			if self._is_dragging:
 				self.set_default_cursor_shape(Control.CURSOR_DRAG)
-		
-				# Move panel while maintaining the original mouse offset
+				get_viewport().set_input_as_handled()
 				new_pos = curr_mouse_pos_global - _drag_offset
 				self.global_position = new_pos
 				self.log(Guidot_Log.Log_Level.DEBUG, ["Dragging panel from", self._last_position, "to", self.global_position])

--- a/gdscript/time_series_graph.gd
+++ b/gdscript/time_series_graph.gd
@@ -66,6 +66,9 @@ class AxisHandler:
 	func set_axis_range(new_range: Vector2) -> void:
 		self._axis_node.setup_axis_range(new_range.x, new_range.y)
 
+	func set_axis_modulation(modulated_color: Color):
+		self._axis_node.set_self_modulate(modulated_color)
+
 	func get_axis_range() -> Vector2:
 		return self._axis_node.get_axis_range()
 
@@ -604,6 +607,8 @@ func _ready() -> void:
 	self._graph_manager.y_axis_changes_applied.connect(self._on_y_axis_changes_applied)
 	self._graph_manager.register_axis_manager(self._y_axis_manager)
 
+	self._graph_manager.opacity_changed.connect(self.set_graph_opacity)
+
 	self._initialized = true
 
 	self.log(LOG_INFO, ["Time series graph initialized"])
@@ -613,6 +618,25 @@ func _ready() -> void:
 # TODO: Implement this with error detection
 func set_window_color(color: Color) -> void:
 	self.color = color
+
+func set_graph_opacity(alpha: float) -> void:
+	
+	# This allows us to finely control the opacity of our graphs and each of its components
+	var a: float = clamp(alpha, 0.0, 1.0)
+	var modulated_color: Color = Color(1.0, 1.0, 1.0, a)
+	self.set_self_modulate(modulated_color)
+	
+	# For the axis, we still want to see the data being plotted, so at minimum, an alpha of 0.3
+	# would still allow you to see the plots nicely
+	a = clamp(alpha, 0.3, 1.0)
+	modulated_color = Color(1.0, 1.0, 1.0, a)
+	self.plot_node.set_self_modulate(modulated_color)
+	self.t_axis_node.set_self_modulate(modulated_color)
+
+	for ax_handler in self._y_axis_manager.get_available_axis_handler():
+		ax_handler.set_axis_modulation(modulated_color)
+
+	queue_redraw()
 
 func _draw():
 	# Data line drawing is handled inside the _draw function of plot_node

--- a/gdscript/time_series_graph.gd
+++ b/gdscript/time_series_graph.gd
@@ -609,6 +609,9 @@ func _ready() -> void:
 
 	self._graph_manager.opacity_changed.connect(self.set_graph_opacity)
 
+	# Ensure that the graph manager is always on top of the display graph
+	self._graph_manager.z_index = self.z_index + 1
+
 	self._initialized = true
 
 	self.log(LOG_INFO, ["Time series graph initialized"])

--- a/scene/graph_2d_prototype.tscn
+++ b/scene/graph_2d_prototype.tscn
@@ -38,17 +38,3 @@ script = ExtResource("5_ax30q")
 
 [node name="Node" type="Node" parent="."]
 script = ExtResource("4_hqxys")
-
-[node name="ColorRect" type="ColorRect" parent="."]
-layout_mode = 0
-offset_left = 155.0
-offset_top = 119.0
-offset_right = 478.0
-offset_bottom = 307.0
-
-[node name="HSlider" type="HSlider" parent="."]
-layout_mode = 0
-offset_right = 235.0
-offset_bottom = 70.0
-editable = false
-tick_count = 10

--- a/scene/graph_2d_prototype.tscn
+++ b/scene/graph_2d_prototype.tscn
@@ -27,6 +27,7 @@ script = ExtResource("1_bb5dl")
 script = ExtResource("2_ct1jo")
 
 [node name="Guidot_Graph" type="PanelContainer" parent="."]
+z_index = 1
 layout_mode = 0
 offset_left = 175.0
 offset_top = 90.0
@@ -37,3 +38,17 @@ script = ExtResource("5_ax30q")
 
 [node name="Node" type="Node" parent="."]
 script = ExtResource("4_hqxys")
+
+[node name="ColorRect" type="ColorRect" parent="."]
+layout_mode = 0
+offset_left = 155.0
+offset_top = 119.0
+offset_right = 478.0
+offset_bottom = 307.0
+
+[node name="HSlider" type="HSlider" parent="."]
+layout_mode = 0
+offset_right = 235.0
+offset_bottom = 70.0
+editable = false
+tick_count = 10


### PR DESCRIPTION
Add:
- Transparency adjustment for graph displays
- Horizontal slider in graph manager to adjust transparency

Fix:
- Multiple selected instances of graph no longer cause weird glitch when moving one of them
- Graph now can be moved smoothly regardless if there is any other node in its way
